### PR TITLE
Make it possible to cut release branches

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 allprojects {
     group = 'com.github.cdcalc'
-    version = '0.0.2'
+    version = '0.0.3-SNAPSHOT'
 }
 
 subprojects {
@@ -30,11 +30,12 @@ subprojects {
     apply plugin: 'kotlin'
     apply plugin: 'jacoco'
 
-    version = '0.0.2'
+    version = '0.0.3-SNAPSHOT'
     ext.kotlin_version = '1.0.5-2'
 
     repositories {
         jcenter()
+        mavenLocal()
     }
 
     dependencies {

--- a/core/src/main/kotlin/com/github/cdcalc/CutReleaseBranch.kt
+++ b/core/src/main/kotlin/com/github/cdcalc/CutReleaseBranch.kt
@@ -1,0 +1,14 @@
+package com.github.cdcalc
+
+import org.eclipse.jgit.api.Git
+
+class CutReleaseBranch(val git: Git) {
+    fun cutReleaseBranch(requiredBranch: String = "develop") {
+        if (requiredBranch != git.repository.branch) {
+            throw InvalidBranchException(requiredBranch, git.repository.branch)
+        }
+    }
+}
+
+class InvalidBranchException(val requiredBranch: String, val currentBranch: String) :
+        Throwable("$requiredBranch is required but current branch is $currentBranch")

--- a/core/src/main/kotlin/com/github/cdcalc/CutReleaseBranch.kt
+++ b/core/src/main/kotlin/com/github/cdcalc/CutReleaseBranch.kt
@@ -1,7 +1,6 @@
 package com.github.cdcalc
 
 import org.eclipse.jgit.api.Git
-import org.eclipse.jgit.transport.CredentialsProvider
 
 class CutReleaseBranch(val git: Git) {
     fun cutReleaseBranch(requiredBranch: String = "develop") {
@@ -12,21 +11,21 @@ class CutReleaseBranch(val git: Git) {
         val latestTag = git.tagList().call()
                 .map { Tag(it.name) }
                 .plus(Tag.Empty)
-                .filter { Tag.Empty != it }
                 .sortedDescending()
                 .first()
 
-        val bumpedVersion = latestTag.bumpMinor()
+        val bumpedVersion = latestTag.bump()
         val releaseBranch = "release/${bumpedVersion.major}.${bumpedVersion.minor}.${bumpedVersion.patch}"
         val releaseTag = "v${bumpedVersion.major}.${bumpedVersion.minor}.${bumpedVersion.patch}-rc.0"
+
         git.branchCreate().setName(releaseBranch).call()
         git.tag()
                 .setMessage("Release candidate $releaseTag")
                 .setName(releaseTag)
                 .call()
 
-        // TODO: putting this under test is almost impossible, we'll need to pass
-        // a list of credential providers
+        // NOTE: it's possible to push to git here but different credentials and since it's hard to test we'll
+        // wait with the implementation below.
         // git.push().setCredentialsProvider(CredentialsProvider.getDefault()).call()
     }
 }

--- a/core/src/main/kotlin/com/github/cdcalc/CutReleaseBranch.kt
+++ b/core/src/main/kotlin/com/github/cdcalc/CutReleaseBranch.kt
@@ -1,14 +1,36 @@
 package com.github.cdcalc
 
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.transport.CredentialsProvider
 
 class CutReleaseBranch(val git: Git) {
     fun cutReleaseBranch(requiredBranch: String = "develop") {
         if (requiredBranch != git.repository.branch) {
             throw InvalidBranchException(requiredBranch, git.repository.branch)
         }
+
+        val latestTag = git.tagList().call()
+                .map { Tag(it.name) }
+                .plus(Tag.Empty)
+                .filter { Tag.Empty != it }
+                .sortedDescending()
+                .first()
+
+        val bumpedVersion = latestTag.bumpMinor()
+        val releaseBranch = "release/${bumpedVersion.major}.${bumpedVersion.minor}.${bumpedVersion.patch}"
+        val releaseTag = "v${bumpedVersion.major}.${bumpedVersion.minor}.${bumpedVersion.patch}-rc.0"
+        git.branchCreate().setName(releaseBranch).call()
+        git.tag()
+                .setMessage("Release candidate $releaseTag")
+                .setName(releaseTag)
+                .call()
+
+        // TODO: putting this under test is almost impossible, we'll need to pass
+        // a list of credential providers
+        // git.push().setCredentialsProvider(CredentialsProvider.getDefault()).call()
     }
 }
 
-class InvalidBranchException(val requiredBranch: String, val currentBranch: String) :
+
+class InvalidBranchException(requiredBranch: String, currentBranch: String) :
         Throwable("$requiredBranch is required but current branch is $currentBranch")

--- a/core/src/main/kotlin/com/github/cdcalc/Tag.kt
+++ b/core/src/main/kotlin/com/github/cdcalc/Tag.kt
@@ -27,6 +27,18 @@ fun Tag(tagName: String): Tag {
     }
 }
 
+fun Tag.bump(): Tag {
+    if (this.major == 0 && this.minor == 0) {
+        return this.bumpPatch()
+    }
+
+    return this.bumpMinor()
+}
+
 fun Tag.bumpMinor(): Tag {
     return this.copy(minor = this.minor + 1, patch = 0)
+}
+
+fun Tag.bumpPatch(): Tag {
+    return this.copy(patch = this.patch + 1)
 }

--- a/core/src/main/kotlin/com/github/cdcalc/Tag.kt
+++ b/core/src/main/kotlin/com/github/cdcalc/Tag.kt
@@ -26,3 +26,7 @@ fun Tag(tagName: String): Tag {
         return Tag(it[1]!!.value.toInt(), it[2]!!.value.toInt(), it[3]!!.value.toInt())
     }
 }
+
+fun Tag.bumpMinor(): Tag {
+    return this.copy(minor = this.minor + 1, patch = 0)
+}

--- a/core/src/main/kotlin/com/github/cdcalc/data/CommitTag.kt
+++ b/core/src/main/kotlin/com/github/cdcalc/data/CommitTag.kt
@@ -1,0 +1,8 @@
+package com.github.cdcalc.data
+
+import org.eclipse.jgit.lib.ObjectId
+
+data class CommitTag (
+        val objectId: ObjectId,
+        val tagName: String
+)

--- a/core/src/main/kotlin/com/github/cdcalc/git/GitExtensions.kt
+++ b/core/src/main/kotlin/com/github/cdcalc/git/GitExtensions.kt
@@ -1,0 +1,18 @@
+package com.github.cdcalc.git
+
+import com.github.cdcalc.data.CommitTag
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.ObjectId
+
+fun Git.taggedCommits(): Map<ObjectId, CommitTag> {
+    val branchCommit: Map<ObjectId, CommitTag> = this.tagList().call().map {
+        val peel = this.repository.peel(it)
+        if (peel.peeledObjectId != null) {
+            CommitTag(peel.peeledObjectId, it.name)
+        } else {
+            CommitTag(it.objectId, it.name)
+        }
+    }.associateBy(keySelector = {it.objectId}, valueTransform = {it})
+
+    return branchCommit
+}

--- a/core/src/main/kotlin/com/github/cdcalc/git/RevWalkExtensions.kt
+++ b/core/src/main/kotlin/com/github/cdcalc/git/RevWalkExtensions.kt
@@ -1,6 +1,6 @@
 package com.github.cdcalc.git
 
-import com.github.cdcalc.strategy.CommitTag
+import com.github.cdcalc.data.CommitTag
 import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.revwalk.RevWalk
 

--- a/core/src/test/kotlin/com/github/cdcalc/CutReleaseBranchTest.kt
+++ b/core/src/test/kotlin/com/github/cdcalc/CutReleaseBranchTest.kt
@@ -35,7 +35,6 @@ class CutReleaseBranchTest {
             it.name == "refs/heads/release/1.1.0" }
 
         val head = git.repository.resolve(Constants.HEAD)
-        git.prettyLog()
 
         assertEquals(head, releaseBranch.objectId)
     }
@@ -48,6 +47,4 @@ class CutReleaseBranchTest {
 
         assertEquals("refs/tags/v1.1.0-rc.0", commitTag!!.tagName)
     }
-
-
 }

--- a/core/src/test/kotlin/com/github/cdcalc/CutReleaseBranchTest.kt
+++ b/core/src/test/kotlin/com/github/cdcalc/CutReleaseBranchTest.kt
@@ -1,0 +1,5 @@
+package com.github.cdcalc
+
+import org.junit.Assert.*
+
+class CutReleaseBranchTest

--- a/core/src/test/kotlin/com/github/cdcalc/CutReleaseBranchTest.kt
+++ b/core/src/test/kotlin/com/github/cdcalc/CutReleaseBranchTest.kt
@@ -1,5 +1,53 @@
 package com.github.cdcalc
 
-import org.junit.Assert.*
+import com.github.cdcalc.git.taggedCommits
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.Constants
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
 
-class CutReleaseBranchTest
+class CutReleaseBranchTest {
+    lateinit var sut: CutReleaseBranch
+    lateinit var git: Git
+
+    @Before fun before() {
+        git = initGitFlow()
+        sut = CutReleaseBranch(git)
+    }
+
+    @After fun after() {
+        git.close()
+    }
+
+    @Test(expected = InvalidBranchException::class)
+    fun shouldThrowIfTryingToCreateReleaseBranchFromDevelop() {
+        git.checkout("master")
+
+        sut.cutReleaseBranch()
+    }
+
+    @Test fun shouldBeAbleToCutReleaseBranch() {
+        sut.cutReleaseBranch()
+
+        val releaseBranch = sut.git.branchList().call().single {
+            it.name == "refs/heads/release/1.1.0" }
+
+        val head = git.repository.resolve(Constants.HEAD)
+        git.prettyLog()
+
+        assertEquals(head, releaseBranch.objectId)
+    }
+
+    @Test fun shouldCreatePreReleaseTag() {
+        sut.cutReleaseBranch()
+
+        val head = git.repository.resolve(Constants.HEAD)
+        val commitTag = git.taggedCommits()[head]
+
+        assertEquals("refs/tags/v1.1.0-rc.0", commitTag!!.tagName)
+    }
+
+
+}

--- a/core/src/test/kotlin/com/github/cdcalc/TagTest.kt
+++ b/core/src/test/kotlin/com/github/cdcalc/TagTest.kt
@@ -1,0 +1,14 @@
+package com.github.cdcalc
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TagTest {
+    @Test fun shouldBumpPatchForNotReleasedPackaged() {
+        assertEquals(Tag(0, 0, 1), Tag.Empty.bump())
+    }
+
+    @Test fun shouldBumpMinorForReleasePackages() {
+        assertEquals(Tag(3, 15, 0), Tag(3, 14, 1).bump())
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,5 @@
-#Wed Nov 23 19:02:49 CET 2016
+# suppress inspection "UnusedProperty" for whole file
+#Tue Feb 21 18:23:07 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/plugin/src/main/kotlin/com/github/cdcalc/gradle/CalculateSemVerPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/cdcalc/gradle/CalculateSemVerPlugin.kt
@@ -6,6 +6,7 @@ import org.gradle.api.Project
 open class CalculateSemVerPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.tasks.create("calculateVersion", CalculateVersionTask::class.java)
+        project.tasks.create("cutReleaseBranch", CutReleaseBranchTask::class.java)
         project.extensions.create("cdcalc", CDCalcExtensions::class.java)
     }
 }

--- a/plugin/src/main/kotlin/com/github/cdcalc/gradle/CalculateVersionTask.kt
+++ b/plugin/src/main/kotlin/com/github/cdcalc/gradle/CalculateVersionTask.kt
@@ -3,11 +3,18 @@ package com.github.cdcalc.gradle
 import com.github.cdcalc.Calculate
 import org.eclipse.jgit.api.Git
 import org.gradle.api.DefaultTask
-import org.gradle.api.GradleScriptException
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
 open class CalculateVersionTask : DefaultTask() {
+    override fun getDescription(): String {
+        return "Will calculate the upcoming version tracking branches and tags"
+    }
+
+    override fun getGroup(): String {
+        return "Release management"
+    }
+
     @Suppress("unused")
     @TaskAction fun calculateVersion() {
         val config: CDCalcExtensions = project.extensions.findByType(CDCalcExtensions::class.java) ?: CDCalcExtensions()

--- a/plugin/src/main/kotlin/com/github/cdcalc/gradle/CutReleaseBranchTask.kt
+++ b/plugin/src/main/kotlin/com/github/cdcalc/gradle/CutReleaseBranchTask.kt
@@ -1,0 +1,25 @@
+package com.github.cdcalc.gradle
+
+import com.github.cdcalc.CutReleaseBranch
+import org.eclipse.jgit.api.Git
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+open class CutReleaseBranchTask : DefaultTask() {
+    override fun getDescription(): String {
+        return "Will cut a release branch and create a release candidate tag"
+    }
+
+    override fun getGroup(): String {
+        return "Release management"
+    }
+
+    @Suppress("unused")
+    @TaskAction fun cutReleaseBranch() {
+        val config: CDCalcExtensions = project.extensions.findByType(CDCalcExtensions::class.java) ?: CDCalcExtensions()
+        val git = Git.open(File(config.repository))
+
+        CutReleaseBranch(git).cutReleaseBranch()
+    }
+}


### PR DESCRIPTION
This is the first take on adding a gradle task `cutReleaseBranch` for cutting a release branch for the upcoming release.