### PR TITLE
Added main method to core project

### DIFF
--- a/core/src/main/kotlin/com/github/cdcalc/Application.kt
+++ b/core/src/main/kotlin/com/github/cdcalc/Application.kt
@@ -1,0 +1,9 @@
+package com.github.cdcalc
+
+import org.eclipse.jgit.api.Git
+import java.io.File
+
+fun main(args: Array<String>) {
+    val git = Git.open(File("./"))
+    Calculate(git).gitFacts()
+}


### PR DESCRIPTION
This makes it possible to run cdcalc without running the gradle plugin.