### PR TITLE
Moved cli to a separate module

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ At the moment there's only a gradle plugin but the core project should be self c
 ### Gradle plugin
 The easiest way to use it, is the gradle plugin https://plugins.gradle.org/plugin/com.github.cdcalc see the `sample` folder for more information.
 
+### CLI
+The CLI is experimental but can be used for debugging at the moment.
+
+```
+./gradlew installDist
+./cli/build/install/cli/bin/cli
+```
+
+The `cli` or `cli.bat` to can be executed from any folder containing a `.git` folder
+
 ## CI
 [![Build Status](https://travis-ci.org/cdcalc/cdcalc.svg?branch=master)](https://travis-ci.org/cdcalc/cdcalc)
 [![codecov](https://codecov.io/gh/cdcalc/cdcalc/branch/master/graph/badge.svg)](https://codecov.io/gh/cdcalc/cdcalc)

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,12 @@ project(':plugin') {
     }
 }
 
+project(':cli') {
+    dependencies {
+        compile project(':core')
+    }
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = "4.0"
 }

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    compile 'ch.qos.logback:logback-classic:1.2.3'
+}
+
+apply plugin: 'application'
+mainClassName = "com.github.cdcalc.cli.ApplicationKt"

--- a/cli/src/main/kotlin/com/github/cdcalc/cli/Application.kt
+++ b/cli/src/main/kotlin/com/github/cdcalc/cli/Application.kt
@@ -1,5 +1,6 @@
-package com.github.cdcalc
+package com.github.cdcalc.cli
 
+import com.github.cdcalc.Calculate
 import org.eclipse.jgit.api.Git
 import java.io.File
 

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+./gradlew installDist
+./cli/build/install/cli/bin/cli

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = 'cdcalc'
-include 'core', 'plugin'
+include 'core', 'plugin', 'cli'


### PR DESCRIPTION
I order to not take a dependency on `logback-classic` for the core module and to be able to evolve the `cli` we'll need to split out the `Application` to a separate module.