### PR TITLE
Make sure develop is only tracking rc.0 tags

### DIFF
--- a/core/src/test/kotlin/com/github/cdcalc/gitflow/DevelopBranchTests.kt
+++ b/core/src/test/kotlin/com/github/cdcalc/gitflow/DevelopBranchTests.kt
@@ -57,4 +57,43 @@ class DevelopBranchTests {
         val result: SemVer = sut.gitFacts().semVer
         assertEquals("1.3.0-beta.1", result.toString())
     }
+
+    @Test
+    fun should_treat_merge_commit_as_one() {
+        git.createTaggedCommit("v1.2.3-rc.0")
+
+        git.checkout("new-feature", true)
+        git.createCommit()
+        git.createCommit()
+
+        git.checkout("develop")
+        git.merge("new-feature")
+
+        git.prettyLog()
+        val result: SemVer = sut.gitFacts().semVer
+        assertEquals("1.3.0-beta.0", result.toString())
+    }
+
+    @Test
+    fun should_handle_reintegrated_develop() {
+        git.createTaggedCommit("v1.2.3-rc.0")
+
+        git.checkout("new-feature", true)
+        git.createCommit()
+        git.createCommit()
+
+        git.checkout("develop")
+        git.createCommit()
+
+        git.checkout("new-feature")
+        git.merge("develop")
+
+        git.checkout("develop")
+        git.merge("new-feature")
+
+        git.prettyLog()
+        val result: SemVer = sut.gitFacts().semVer
+        assertEquals("1.3.0-beta.1", result.toString())
+    }
+
 }

--- a/core/src/test/kotlin/com/github/cdcalc/gitflow/DevelopBranchTests.kt
+++ b/core/src/test/kotlin/com/github/cdcalc/gitflow/DevelopBranchTests.kt
@@ -96,4 +96,55 @@ class DevelopBranchTests {
         assertEquals("1.3.0-beta.1", result.toString())
     }
 
+    @Test
+    fun should_handle_release() {
+        git.createTaggedCommit("v1.2.3-rc.0")
+        git.checkout("release/1.2.3", true).createCommit()
+        git.checkout("develop").createCommit()
+
+        git.checkout("develop").merge("release/1.2.3")
+        git.checkout("master").merge("release/1.2.3")
+        git.tag().let {
+            it.name = "v1.2.3"
+            it.message = "v1.2.3"
+            it.call()
+        }
+
+        git.checkout("develop")
+        val result: SemVer = sut.gitFacts().semVer
+        assertEquals("1.3.0-beta.1", result.toString())
+    }
+
+    @Test
+    fun should_handle_hotfix() {
+        git.createTaggedCommit("v1.2.3-rc.0")
+        git.checkout("release/1.2.3", true).createCommit()
+        git.checkout("develop").createCommit()
+
+        git.checkout("develop").merge("release/1.2.3")
+        git.checkout("master").merge("release/1.2.3")
+        git.tag().let {
+            it.name = "v1.2.3"
+            it.message = "v1.2.3"
+            it.call()
+        }
+
+        git.checkout("hotfix/1.2.4", true)
+        git.createCommit().createCommit()
+
+        git.checkout("master").merge("hotfix/1.2.4")
+        git.tag().let {
+            it.name = "v1.2.4"
+            it.message = "v1.2.4"
+            it.call()
+        }
+
+        git.checkout("develop").merge("hotfix/1.2.4")
+
+        git.prettyLog()
+
+        val result: SemVer = sut.gitFacts().semVer
+        assertEquals("1.3.0-beta.2", result.toString())
+    }
+
 }

--- a/core/src/test/kotlin/com/github/cdcalc/gitflow/DevelopBranchTests.kt
+++ b/core/src/test/kotlin/com/github/cdcalc/gitflow/DevelopBranchTests.kt
@@ -2,6 +2,7 @@ package com.github.cdcalc.gitflow
 
 import com.github.cdcalc.*
 import com.github.cdcalc.data.SemVer
+import com.github.cdcalc.strategy.TrackingException
 import org.eclipse.jgit.api.Git
 import org.junit.Before
 import org.junit.Test
@@ -17,14 +18,12 @@ class DevelopBranchTests {
         sut = Calculate(git)
     }
 
-    @Test
+    @Test(expected = TrackingException::class)
     fun should_resolve_master_branch() {
-        val result: GitFacts = sut.gitFacts()
-
-        assertEquals(SemVer(1,1,0, listOf("beta", "0")), result.semVer)
+        sut.gitFacts()
     }
 
-    @Test
+    @Test(expected = TrackingException::class)
     fun should_stay_on_same_version_independent_on_tag() {
         git.tag().let {
             it.name = "v1.1.0-rc.0"
@@ -32,9 +31,7 @@ class DevelopBranchTests {
             it.call()
         }
 
-        val result: GitFacts = sut.gitFacts()
-
-        assertEquals(SemVer(1,1,0, listOf("beta", "0")), result.semVer)
+        sut.gitFacts()
     }
 
     @Test


### PR DESCRIPTION
This solution is not perfect since it makes the start harder e.g. before we're not having a `rc.0` but that's better then picking up a release tag by misstake. A possible improvement in the future is to process `rc.0` before any stable tag.

Note that we're not counting any `rc.0` that point to the current commit to make sure it's possible to do deterministic builds, e.g. we cannot change the version of `1.0.0-beta.1337` to `1.1.0-beta.0` just because we have added a `rc.0` tag