### PR TITLE
Add result as extra properties for the calculateVersion task

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,21 +1,13 @@
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "com.gradle.publish:plugin-publish-plugin:0.9.9"
-    }
+plugins {
+    id 'java-gradle-plugin'
+    id 'maven-publish'
+    id 'com.gradle.plugin-publish' version '0.9.9'
 }
 
 dependencies {
     compile gradleApi()
+    testCompile gradleTestKit()
 }
-
-apply plugin: 'maven-publish'
-apply plugin: "com.gradle.plugin-publish"
-
 
 publishing {
     publications {

--- a/plugin/src/main/kotlin/com/github/cdcalc/gradle/CDCalcExtensions.kt
+++ b/plugin/src/main/kotlin/com/github/cdcalc/gradle/CDCalcExtensions.kt
@@ -1,8 +1,13 @@
 package com.github.cdcalc.gradle
 
-open class CDCalcExtensions() {
+open class CDCalcExtensions {
     var repository: String = ".git"
-    var calculatedVersion: String = "0.0.1"
-    var branch: String = ""
+
+    @Deprecated("Will be removed in v0.1.0, since it's not needed any more")
     var trackOrigin: String = "origin/"
+
+    @Deprecated("Will be removed in v0.1.0, use calculateVersion.version instead")
+    var calculatedVersion: String = "0.0.1"
+    @Deprecated("Will be removed in v0.1.0, use calculateVersion.branch instead")
+    var branch: String = ""
 }

--- a/plugin/src/main/kotlin/com/github/cdcalc/gradle/CalculateVersionTask.kt
+++ b/plugin/src/main/kotlin/com/github/cdcalc/gradle/CalculateVersionTask.kt
@@ -2,28 +2,31 @@ package com.github.cdcalc.gradle
 
 import com.github.cdcalc.Calculate
 import com.github.cdcalc.CalculateSetting
+import com.github.cdcalc.GitFacts
 import org.eclipse.jgit.api.Git
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
 open class CalculateVersionTask : DefaultTask() {
-    override fun getDescription(): String {
-        return "Will calculate the upcoming version tracking branches and tags"
+    init {
+        group = "Release management"
+        description = "Will calculate the upcoming version tracking branches and tags"
     }
 
-    override fun getGroup(): String {
-        return "Release management"
-    }
-
-    @Suppress("unused")
     @TaskAction fun calculateVersion() {
         val config: CDCalcExtensions = project.extensions.findByType(CDCalcExtensions::class.java) ?: CDCalcExtensions()
-
         val git = Git.open(File(config.repository))
         val gitFacts = Calculate(git, CalculateSetting(config.trackOrigin)).gitFacts()
 
         config.calculatedVersion = gitFacts.semVer.toString()
         config.branch = gitFacts.branch
+
+        addProperties(gitFacts)
+    }
+
+    private fun addProperties(facts: GitFacts) {
+        extensions.extraProperties["branch"] = facts.branch
+        extensions.extraProperties["version"] = facts.semVer.toString()
     }
 }

--- a/plugin/src/test/kotlin/com/github/cdcalc/gradle/CalculateVersionTaskTest.kt
+++ b/plugin/src/test/kotlin/com/github/cdcalc/gradle/CalculateVersionTaskTest.kt
@@ -1,0 +1,110 @@
+package com.github.cdcalc.gradle
+
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.PersonIdent
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.slf4j.LoggerFactory
+import java.io.File
+import kotlin.test.assertTrue
+
+class CalculateVersionTaskFunctionalTest {
+    private val log = LoggerFactory.getLogger(CalculateVersionTaskFunctionalTest::class.java)
+
+    @Rule @JvmField val testProjectDir = TemporaryFolder()
+    private lateinit var buildFile: File
+
+    @Before fun before() {
+        buildFile = testProjectDir.newFile("build.gradle")
+        log.debug("Gradle file:" + buildFile.absolutePath)
+    }
+
+    @Test fun `Should add an extra property for version at calculateVersion`() {
+        val content = """
+            plugins {
+              id "com.github.cdcalc"
+            }
+
+            cdcalc {
+                repository '.git'
+            }
+
+            task printVersion(dependsOn: 'calculateVersion') {
+                doLast {
+                    println "assertVersion[${'$'}calculateVersion.version]"
+                }
+            }
+        """.trimIndent()
+        buildFile.writeText(content)
+
+        gitInit(testProjectDir.root)
+                .commit("Initial commit")
+                .tag("v1.2.3")
+
+        val result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir.root)
+                .withArguments("printVersion", "-Duser.dir=${testProjectDir.root}")
+                .withDebug(true)
+                .build()
+
+        val task = result.task(":printVersion")!!
+        assertEquals(task.outcome, SUCCESS)
+        assertTrue(result.output.contains("assertVersion[1.2.3]"), "assertVersion[1.2.3] should be present in: ${result.output}")
+    }
+
+    @Test fun `Should add an extra property for branch at calculateVersion`() {
+        val content = """
+            plugins {
+              id "com.github.cdcalc"
+            }
+
+            cdcalc {
+                repository '.git'
+            }
+
+            task printBranch(dependsOn: 'calculateVersion') {
+                doLast {
+                    println "assertBranch[${'$'}calculateVersion.branch]"
+                }
+            }
+        """.trimIndent()
+        buildFile.writeText(content)
+
+        gitInit(testProjectDir.root)
+                .commit("Initial commit")
+                .tag("v1.2.3")
+
+        val result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir.root)
+                .withArguments("printBranch", "-Duser.dir=${testProjectDir.root}")
+                .withDebug(true)
+                .build()
+
+        val task = result.task(":printBranch")!!
+        assertEquals(task.outcome, SUCCESS)
+        assertTrue(result.output.contains("assertBranch[master]"), "assertBranch[master] should be present in: ${result.output}")
+    }
+
+    private fun gitInit(root: File): Git = Git.init().setDirectory(root).call()
+
+    private fun Git.tag(tag: String): Git {
+        this.tag().setName(tag).call()
+        return this
+    }
+
+    private fun Git.commit(message: String = "create file"): Git {
+        val commit = this.commit()
+        commit.author = PersonIdent("Örjan Sjöholm", "orjan.sjoholm@gmail.com")
+        commit.setAll(true)
+        commit.message = message
+        commit.call()
+        return this
+    }
+}


### PR DESCRIPTION
At the moment we're mutating the `cdcalc { }` extension that makes the code hard to follow.
This pull request resolves #37 by adding the result to the task itself so it can be accessed via:
- calculateVersion.task
- calculateVersion.branch