### PR TITLE
Control output by using a logger instead of println

### DIFF
--- a/cli/src/main/kotlin/com/github/cdcalc/cli/Application.kt
+++ b/cli/src/main/kotlin/com/github/cdcalc/cli/Application.kt
@@ -1,10 +1,16 @@
 package com.github.cdcalc.cli
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
 import com.github.cdcalc.Calculate
 import org.eclipse.jgit.api.Git
 import java.io.File
 
+
 fun main(args: Array<String>) {
+    val root = org.slf4j.LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as Logger
+    root.level = Level.WARN
+
     val git = Git.open(File("./"))
-    Calculate(git).gitFacts()
+    Calculate(git).gitFacts(::println)
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     compile 'org.eclipse.jgit:org.eclipse.jgit:4.10.0.201712302008-r'
-    testCompile 'org.slf4j:slf4j-nop:1.7.21'
+    testRuntime 'ch.qos.logback:logback-classic:1.2.3'
 }
 
 apply plugin: 'maven-publish'

--- a/core/src/main/kotlin/com/github/cdcalc/Calculate.kt
+++ b/core/src/main/kotlin/com/github/cdcalc/Calculate.kt
@@ -1,9 +1,12 @@
 package com.github.cdcalc
 
+import com.github.cdcalc.configuration.BuildEnvironment
 import com.github.cdcalc.configuration.EnvironmentConfiguration
 import com.github.cdcalc.configuration.resolveEnvironmentConfiguration
 import com.github.cdcalc.data.SemVer
 import org.eclipse.jgit.api.Git
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.io.File
 
 
@@ -12,24 +15,29 @@ class Calculate(
         private val calculateSettings: CalculateSettings = CalculateSettings(),
         private val resolveEnvironmentConfiguration: (Git) -> EnvironmentConfiguration = resolveEnvironmentConfiguration()
 ) {
-    fun gitFacts(): GitFacts {
+    private val log: Logger = LoggerFactory.getLogger(Calculate::class.java)
+
+    fun gitFacts(printVersion: (String) -> Unit = log::info): GitFacts {
         val (buildEnvironment, branch) = resolveEnvironmentConfiguration(git)
 
-        println("Resolved branch $branch running in the context of $buildEnvironment")
+        this.log.info("Resolved branch $branch running in the context of $buildEnvironment")
 
         val semVer: SemVer = (com.github.cdcalc.strategy.findBranchStrategy(branch))(git, CalculateConfiguration(branch))
 
         val gitFacts = GitFacts(branch = branch, semVer = semVer)
 
-        sendBuildNumberToCI(gitFacts)
+        outputBuildNumber(buildEnvironment, gitFacts, printVersion)
         writeVersionToFile(calculateSettings, gitFacts)
 
         return gitFacts
     }
+}
 
-    fun sendBuildNumberToCI(gitFacts: GitFacts) {
-        // TODO: this output is TC specific and need to be extracted later on.
-        println("##teamcity[buildNumber '${gitFacts.semVer}']")
+internal fun outputBuildNumber(buildEnvironment: BuildEnvironment, gitFacts: GitFacts, output: (String) -> Unit) {
+    if (buildEnvironment == BuildEnvironment.TeamCity) {
+        output("##teamcity[buildNumber '${gitFacts.semVer}']")
+    } else {
+        output(gitFacts.semVer.toString())
     }
 }
 

--- a/core/src/main/kotlin/com/github/cdcalc/configuration/BuildEnvironment.kt
+++ b/core/src/main/kotlin/com/github/cdcalc/configuration/BuildEnvironment.kt
@@ -1,5 +1,5 @@
 package com.github.cdcalc.configuration
 
 enum class BuildEnvironment {
-    StandAlone, GitLab
+    StandAlone, GitLab, TeamCity
 }

--- a/core/src/main/kotlin/com/github/cdcalc/configuration/EnvironmentConfiguration.kt
+++ b/core/src/main/kotlin/com/github/cdcalc/configuration/EnvironmentConfiguration.kt
@@ -15,6 +15,10 @@ private fun buildConfiguration(git: Git, environment: (String) -> String?) : Env
         return EnvironmentConfiguration(BuildEnvironment.GitLab, environment("CI_COMMIT_REF_NAME")!!)
     }
 
+    if (!environment("TEAMCITY_VERSION").isNullOrEmpty()) {
+        return EnvironmentConfiguration(BuildEnvironment.TeamCity, git.repository.branch)
+    }
+
     return EnvironmentConfiguration(BuildEnvironment.StandAlone, git.repository.branch)
 }
 

--- a/core/src/main/kotlin/com/github/cdcalc/git/GitExtensions.kt
+++ b/core/src/main/kotlin/com/github/cdcalc/git/GitExtensions.kt
@@ -8,6 +8,8 @@ import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.revwalk.RevWalk
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 fun Git.taggedCommits(): Map<ObjectId, CommitTag> {
     val branchCommit: Map<ObjectId, CommitTag> = this.tagList().call().map {
@@ -54,6 +56,7 @@ fun <T> Git.processTags(tags: List<RefSemVer>, filter: (walk: RevWalk, headCommi
 }
 
 fun Git.aheadOfTag(tags: List<RefSemVer>, ignoreTagsOnHead: Boolean = false) : SemVerAhead {
+    val log: Logger = LoggerFactory.getLogger(::aheadOfTag.name)
     val semVerAhead = processTags(tags) { walk, headCommit, sequence ->
         sequence.filter { (taggedCommit) ->
             when {
@@ -61,7 +64,7 @@ fun Git.aheadOfTag(tags: List<RefSemVer>, ignoreTagsOnHead: Boolean = false) : S
                 else -> walk.isMergedInto(taggedCommit, headCommit)
             }
         }.map { (taggedCommit, semVer: SemVer) ->
-            println("Check if " + headCommit.name + " is merged into " + taggedCommit.name)
+                    log.info("Check if " + headCommit.name + " is merged into " + taggedCommit.name)
             SemVerAhead(
                     semVer,
                     walk.countCommits(headCommit, taggedCommit),

--- a/core/src/main/kotlin/com/github/cdcalc/strategy/GitFlowStrategyResolver.kt
+++ b/core/src/main/kotlin/com/github/cdcalc/strategy/GitFlowStrategyResolver.kt
@@ -19,8 +19,6 @@ fun matches(searchString: String): (String) -> Boolean {
 }
 
 fun findBranchStrategy(branch: String): (org.eclipse.jgit.api.Git, com.github.cdcalc.CalculateConfiguration) -> SemVer {
-    println("Trying to find matching branch for: " + branch)
-
     val strategies = listOf(
             Pair(com.github.cdcalc.strategy.match("master"), versionForMasterBranch()),
             Pair(com.github.cdcalc.strategy.matches("hotfix/.*"), versionForHotfixBranch()),

--- a/core/src/test/kotlin/com/github/cdcalc/CalculateTest.kt
+++ b/core/src/test/kotlin/com/github/cdcalc/CalculateTest.kt
@@ -1,5 +1,6 @@
 package com.github.cdcalc
 
+import com.github.cdcalc.configuration.BuildEnvironment
 import com.github.cdcalc.data.SemVer
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -13,5 +14,17 @@ class CalculateTest {
         val versionFile = tempDir.newFile()
         writeVersionToFile(CalculateSettings(versionFile = versionFile), GitFacts("master", SemVer(1,2,3)))
         assertEquals("1.2.3", versionFile.readText())
+    }
+
+    @Test fun `Should output TeamCity build number`(){
+        outputBuildNumber(BuildEnvironment.TeamCity, GitFacts(branch = "master", semVer = SemVer(1,2,3)), {
+            assertEquals("##teamcity[buildNumber '1.2.3']", it)
+        })
+    }
+
+    @Test fun `Should output plain number for standalone`(){
+        outputBuildNumber(BuildEnvironment.StandAlone, GitFacts(branch = "master", semVer = SemVer(1,2,3)), {
+            assertEquals("1.2.3", it)
+        })
     }
 }

--- a/core/src/test/kotlin/com/github/cdcalc/GitFlowTests.kt
+++ b/core/src/test/kotlin/com/github/cdcalc/GitFlowTests.kt
@@ -94,7 +94,6 @@ class GitFlowTests {
         assertEquals("2.1.0-beta.1", result.semVer.toString())
     }
 
-
     @Test fun find_latest() {
         git.checkout("develop").createCommit().createCommit()
         git.checkout("feature/foo", true).createCommit().createCommit().createCommit()
@@ -115,29 +114,9 @@ class GitFlowTests {
             it.name == "refs/heads/master"
         }
 
-
         val calculateDivergence = git.calculateDivergence(develop, master)
-        println(calculateDivergence)
+        assertEquals(CommitCount(behind=1, ahead=7), calculateDivergence)
     }
-
-    @Suppress("UNUSED_VARIABLE")
-    @Test fun fetchSomeAuthorData() {
-
-        val revWalk = RevWalk(git.repository)
-        val parseCommit = revWalk.parseCommit(git.repository.findRef("master").objectId)
-
-
-        val authorIdent = parseCommit.getAuthorIdent();
-        val authorDate = authorIdent.getWhen();
-        val authorTimeZone = authorIdent.getTimeZone();
-
-        Instant.EPOCH
-        println(parseCommit.shortMessage)
-        println(parseCommit)
-        println(Instant.now().epochSecond)
-    }
-
-
 }
 
 fun Git.calculateDivergence(local: Ref, tracking: Ref): CommitCount {
@@ -161,7 +140,6 @@ fun Git.calculateDivergence(local: Ref, tracking: Ref): CommitCount {
         return CommitCount(behindCount, aheadCount)
     }
 }
-data class CommitCount(val behind: Int, val ahead: Int) {
 
-}
+data class CommitCount(val behind: Int, val ahead: Int)
 

--- a/core/src/test/kotlin/com/github/cdcalc/configuration/EnvironmentConfigurationTest.kt
+++ b/core/src/test/kotlin/com/github/cdcalc/configuration/EnvironmentConfigurationTest.kt
@@ -37,6 +37,17 @@ class EnvironmentConfigurationTest {
         assertEquals(EnvironmentConfiguration(BuildEnvironment.GitLab, "master"), configuration)
     }
 
+    @Test fun `Should resolve TeamCity configuration`() {
+        val resolveConfiguration = resolveEnvironmentConfiguration(
+                fakeEnvironment(mapOf(Pair("TEAMCITY_VERSION", "10")))
+        )
+        git.checkout("master")
+
+        val configuration = resolveConfiguration(git)
+
+        assertEquals(EnvironmentConfiguration(BuildEnvironment.TeamCity, "master"), configuration)
+    }
+
     fun fakeEnvironment(variables: Map<String, String>): (String) -> String? {
         return {
             variables[it]

--- a/core/src/test/kotlin/com/github/cdcalc/gitflow/DevelopBranchTests.kt
+++ b/core/src/test/kotlin/com/github/cdcalc/gitflow/DevelopBranchTests.kt
@@ -69,7 +69,6 @@ class DevelopBranchTests {
         git.checkout("develop")
         git.merge("new-feature")
 
-        git.prettyLog()
         val result: SemVer = sut.gitFacts().semVer
         assertEquals("1.3.0-beta.0", result.toString())
     }
@@ -91,7 +90,6 @@ class DevelopBranchTests {
         git.checkout("develop")
         git.merge("new-feature")
 
-        git.prettyLog()
         val result: SemVer = sut.gitFacts().semVer
         assertEquals("1.3.0-beta.1", result.toString())
     }
@@ -140,8 +138,6 @@ class DevelopBranchTests {
         }
 
         git.checkout("develop").merge("hotfix/1.2.4")
-
-        git.prettyLog()
 
         val result: SemVer = sut.gitFacts().semVer
         assertEquals("1.3.0-beta.2", result.toString())

--- a/plugin/src/main/kotlin/com/github/cdcalc/gradle/CalculateVersionTask.kt
+++ b/plugin/src/main/kotlin/com/github/cdcalc/gradle/CalculateVersionTask.kt
@@ -16,7 +16,8 @@ open class CalculateVersionTask : DefaultTask() {
     @TaskAction fun calculateVersion() {
         val config: CDCalcExtensions = project.extensions.findByType(CDCalcExtensions::class.java) ?: CDCalcExtensions()
         val git = Git.open(config.repository)
-        val gitFacts = Calculate(git, CalculateSettings(versionFile = config.versionFile)).gitFacts()
+        val gitFacts = Calculate(git, CalculateSettings(versionFile = config.versionFile))
+                .gitFacts(logger::lifecycle)
 
         addProperties(gitFacts)
     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -11,7 +11,7 @@ plugins {
 version = '0.0.1-SNAPSHOT'
 
 cdcalc {
-    repository = '../.git'
+    repository = file('../.git')
 }
 
 task publish(dependsOn: 'calculateVersion', description: 'Publish artifacts to Nexus', group: 'Publishing') {


### PR DESCRIPTION
In order to control the output we cannot use println in the production code.
With slf4j in place we can use a runtime nop-logger if we don't want to output anything.
This goes hand in hand with the gradle logger that intercepts slf4j.